### PR TITLE
Replace int64 with int32

### DIFF
--- a/server/internal/circ/reader_test.go
+++ b/server/internal/circ/reader_test.go
@@ -36,15 +36,15 @@ func TestReadFrom(t *testing.T) {
 	_, err := buf.ReadFrom(br)
 	require.NoError(t, err)
 	require.Equal(t, bytes.Repeat([]byte{'-'}, 4), buf.buf[:4])
-	require.Equal(t, int64(4), buf.head)
+	require.Equal(t, int32(4), buf.head)
 
 	br.Reset(b4)
 	_, err = buf.ReadFrom(br)
-	require.Equal(t, int64(8), buf.head)
+	require.Equal(t, int32(8), buf.head)
 
 	br.Reset(b4)
 	_, err = buf.ReadFrom(br)
-	require.Equal(t, int64(12), buf.head)
+	require.Equal(t, int32(12), buf.head)
 }
 
 func TestReadFromWrap(t *testing.T) {
@@ -60,15 +60,15 @@ func TestReadFromWrap(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 100)
 	go func() {
-		atomic.StoreInt64(&buf.done, 1)
+		atomic.StoreInt32(&buf.done, 1)
 		buf.rcond.L.Lock()
 		buf.rcond.Broadcast()
 		buf.rcond.L.Unlock()
 	}()
 	<-o
 	require.Equal(t, []byte{'/', '/', '/', '/', '/', '/', '-', '-', '-', '-', '-', '-', '-', '-', '/', '/'}, buf.Get())
-	require.Equal(t, int64(22), atomic.LoadInt64(&buf.head))
-	require.Equal(t, 6, buf.Index(atomic.LoadInt64(&buf.head)))
+	require.Equal(t, int32(22), atomic.LoadInt32(&buf.head))
+	require.Equal(t, 6, buf.Index(atomic.LoadInt32(&buf.head)))
 }
 
 func TestReadOK(t *testing.T) {
@@ -76,8 +76,8 @@ func TestReadOK(t *testing.T) {
 	buf.buf = []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'}
 
 	tests := []struct {
-		tail  int64
-		head  int64
+		tail  int32
+		head  int32
 		n     int
 		bytes []byte
 		desc  string
@@ -96,7 +96,7 @@ func TestReadOK(t *testing.T) {
 		}()
 
 		time.Sleep(time.Millisecond)
-		atomic.StoreInt64(&buf.head, buf.head+int64(tt.n))
+		atomic.StoreInt32(&buf.head, buf.head+int32(tt.n))
 
 		buf.wcond.L.Lock()
 		buf.wcond.Broadcast()
@@ -116,7 +116,7 @@ func TestReadEnded(t *testing.T) {
 		o <- err
 	}()
 	time.Sleep(time.Millisecond)
-	atomic.StoreInt64(&buf.done, 1)
+	atomic.StoreInt32(&buf.done, 1)
 	buf.wcond.L.Lock()
 	buf.wcond.Broadcast()
 	buf.wcond.L.Unlock()

--- a/server/internal/circ/writer_test.go
+++ b/server/internal/circ/writer_test.go
@@ -31,8 +31,8 @@ func TestNewWriterFromSlice(t *testing.T) {
 
 func TestWriteTo(t *testing.T) {
 	tests := []struct {
-		tail  int64
-		head  int64
+		tail  int32
+		head  int32
 		bytes []byte
 		await int
 		total int
@@ -59,7 +59,7 @@ func TestWriteTo(t *testing.T) {
 		}()
 
 		time.Sleep(time.Millisecond * 100)
-		atomic.StoreInt64(&buf.done, 1)
+		atomic.StoreInt32(&buf.done, 1)
 		buf.wcond.L.Lock()
 		buf.wcond.Broadcast()
 		buf.wcond.L.Unlock()
@@ -94,9 +94,9 @@ func TestWriteToBadWriter(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	tests := []struct {
-		tail  int64
-		head  int64
-		rHead int64
+		tail  int32
+		head  int32
+		rHead int32
 		bytes []byte
 		want  []byte
 		desc  string
@@ -132,8 +132,8 @@ func TestWriteEnded(t *testing.T) {
 
 func TestWriteBytes(t *testing.T) {
 	tests := []struct {
-		tail  int64
-		head  int64
+		tail  int32
+		head  int32
 		bytes []byte
 		want  []byte
 		start int

--- a/server/internal/clients/clients_test.go
+++ b/server/internal/clients/clients_test.go
@@ -316,8 +316,8 @@ func TestClientStart(t *testing.T) {
 	cl.Start()
 	defer cl.Stop()
 	time.Sleep(time.Millisecond)
-	require.Equal(t, int64(1), atomic.LoadInt64(&cl.r.State))
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.w.State))
+	require.Equal(t, int32(1), atomic.LoadInt32(&cl.r.State))
+	require.Equal(t, int32(2), atomic.LoadInt32(&cl.w.State))
 }
 
 func BenchmarkClientStart(b *testing.B) {
@@ -340,11 +340,11 @@ func TestClientReadFixedHeader(t *testing.T) {
 	fh := new(packets.FixedHeader)
 	err := cl.ReadFixedHeader(fh)
 	require.NoError(t, err)
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.system.BytesRecv))
+	require.Equal(t, int32(2), atomic.LoadInt32(&cl.system.BytesRecv))
 
 	tail, head := cl.r.GetPos()
-	require.Equal(t, int64(2), tail)
-	require.Equal(t, int64(2), head)
+	require.Equal(t, int32(2), tail)
+	require.Equal(t, int32(2), head)
 
 }
 
@@ -419,7 +419,7 @@ func TestClientReadOK(t *testing.T) {
 
 	err := cl.r.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.r.SetPos(0, int32(len(b)))
 
 	o := make(chan error)
 	var pks []packets.Packet
@@ -456,8 +456,8 @@ func TestClientReadOK(t *testing.T) {
 		},
 	})
 
-	require.Equal(t, int64(len(b)), atomic.LoadInt64(&cl.system.BytesRecv))
-	require.Equal(t, int64(2), atomic.LoadInt64(&cl.system.MessagesRecv))
+	require.Equal(t, int32(len(b)), atomic.LoadInt32(&cl.system.BytesRecv))
+	require.Equal(t, int32(2), atomic.LoadInt32(&cl.system.MessagesRecv))
 
 }
 
@@ -487,7 +487,7 @@ func TestClientReadPacketError(t *testing.T) {
 	}
 	err := cl.r.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.r.SetPos(0, int32(len(b)))
 
 	o := make(chan error)
 	go func() {
@@ -513,7 +513,7 @@ func TestClientReadHandlerErr(t *testing.T) {
 
 	err := cl.r.Set(b, 0, len(b))
 	require.NoError(t, err)
-	cl.r.SetPos(0, int64(len(b)))
+	cl.r.SetPos(0, int32(len(b)))
 
 	err = cl.Read(func(cl *Client, pk packets.Packet) error {
 		return errors.New("test")
@@ -562,7 +562,7 @@ func TestClientReadPacket(t *testing.T) {
 	for i, tt := range pkTable {
 		err := cl.r.Set(tt.bytes, 0, len(tt.bytes))
 		require.NoError(t, err)
-		cl.r.SetPos(0, int64(len(tt.bytes)))
+		cl.r.SetPos(0, int32(len(tt.bytes)))
 
 		fh := new(packets.FixedHeader)
 		err = cl.ReadFixedHeader(fh)
@@ -574,7 +574,7 @@ func TestClientReadPacket(t *testing.T) {
 
 		require.Equal(t, tt.packet, pk, "Mismatched packet: [i:%d] %d", i, tt.bytes[0])
 		if tt.packet.FixedHeader.Type == packets.Publish {
-			require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.PublishRecv))
+			require.Equal(t, int32(1), atomic.LoadInt32(&cl.system.PublishRecv))
 		}
 	}
 }
@@ -647,10 +647,10 @@ func TestClientWritePacket(t *testing.T) {
 
 		require.Equal(t, tt.bytes, <-o, "Mismatched packet: [i:%d] %d", i, tt.bytes[0])
 		cl.Stop()
-		require.Equal(t, int64(n), atomic.LoadInt64(&cl.system.BytesSent))
-		require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.MessagesSent))
+		require.Equal(t, int32(n), atomic.LoadInt32(&cl.system.BytesSent))
+		require.Equal(t, int32(1), atomic.LoadInt32(&cl.system.MessagesSent))
 		if tt.packet.FixedHeader.Type == packets.Publish {
-			require.Equal(t, int64(1), atomic.LoadInt64(&cl.system.PublishSent))
+			require.Equal(t, int32(1), atomic.LoadInt32(&cl.system.PublishSent))
 		}
 	}
 }

--- a/server/internal/topics/trie.go
+++ b/server/internal/topics/trie.go
@@ -29,8 +29,8 @@ func New() *Index {
 // RetainMessage saves a message payload to the end of a topic branch. Returns
 // 1 if a retained message was added, 0 if there was no change, and -1 if the
 // retained message was removed.
-func (x *Index) RetainMessage(msg packets.Packet) int64 {
-	var q int64
+func (x *Index) RetainMessage(msg packets.Packet) int32 {
+	var q int32
 
 	x.mu.Lock()
 	defer x.mu.Unlock()

--- a/server/internal/topics/trie_test.go
+++ b/server/internal/topics/trie_test.go
@@ -99,7 +99,7 @@ func TestRetainMessage(t *testing.T) {
 
 	index := New()
 	q := index.RetainMessage(pk)
-	require.Equal(t, int64(1), q)
+	require.Equal(t, int32(1), q)
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"])
 	require.Equal(t, pk, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"].Message)
 
@@ -108,13 +108,13 @@ func TestRetainMessage(t *testing.T) {
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"])
 
 	q = index.RetainMessage(pk2)
-	require.Equal(t, int64(1), q)
+	require.Equal(t, int32(1), q)
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"])
 	require.Equal(t, pk2, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message)
 	require.Contains(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Clients, "client-1")
 
 	q = index.RetainMessage(pk2) // already exsiting
-	require.Equal(t, int64(0), q)
+	require.Equal(t, int32(0), q)
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"])
 	require.Equal(t, pk2, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message)
 	require.Contains(t, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Clients, "client-1")
@@ -122,7 +122,7 @@ func TestRetainMessage(t *testing.T) {
 	// Delete retained
 	pk3 := packets.Packet{TopicName: "path/to/another/mqtt", Payload: []byte{}}
 	q = index.RetainMessage(pk3)
-	require.Equal(t, int64(-1), q)
+	require.Equal(t, int32(-1), q)
 	require.NotNil(t, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"])
 	require.Equal(t, pk, index.Root.Leaves["path"].Leaves["to"].Leaves["my"].Leaves["mqtt"].Message)
 	require.Equal(t, false, index.Root.Leaves["path"].Leaves["to"].Leaves["another"].Leaves["mqtt"].Message.FixedHeader.Retain)

--- a/server/listeners/http_sysinfo.go
+++ b/server/listeners/http_sysinfo.go
@@ -22,7 +22,7 @@ type HTTPStats struct {
 	system  *system.Info // pointers to the server data.
 	address string       // the network address to bind to.
 	listen  *http.Server // the http server.
-	end     int64        // ensure the close methods are only called once.}
+	end     int32        // ensure the close methods are only called once.}
 }
 
 // NewHTTPStats initialises and returns a new HTTP listener, listening on an address.
@@ -98,8 +98,8 @@ func (l *HTTPStats) Close(closeClients CloseFunc) {
 	l.Lock()
 	defer l.Unlock()
 
-	if atomic.LoadInt64(&l.end) == 0 {
-		atomic.StoreInt64(&l.end, 1)
+	if atomic.LoadInt32(&l.end) == 0 {
+		atomic.StoreInt32(&l.end, 1)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/server/listeners/websocket.go
+++ b/server/listeners/websocket.go
@@ -33,7 +33,7 @@ type Websocket struct {
 	config    *Config       // configuration values for the listener.
 	address   string        // the network address to bind to.
 	listen    *http.Server  // an http server for serving websocket connections.
-	end       int64         // ensure the close methods are only called once.
+	end       int32         // ensure the close methods are only called once.
 	establish EstablishFunc // the server's establish conection handler.
 }
 
@@ -161,8 +161,8 @@ func (l *Websocket) Close(closeClients CloseFunc) {
 	l.Lock()
 	defer l.Unlock()
 
-	if atomic.LoadInt64(&l.end) == 0 {
-		atomic.StoreInt64(&l.end, 1)
+	if atomic.LoadInt32(&l.end) == 0 {
+		atomic.StoreInt32(&l.end, 1)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		l.listen.Shutdown(ctx)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -581,7 +581,7 @@ func TestServerProcessPublishQoS1Retain(t *testing.T) {
 		ack2 <- buf
 	}()
 
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.PublishRecv))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.PublishRecv))
 
 	err := s.processPacket(cl1, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -612,7 +612,7 @@ func TestServerProcessPublishQoS1Retain(t *testing.T) {
 		'h', 'e', 'l', 'l', 'o',
 	}, <-ack2)
 
-	require.Equal(t, int64(1), atomic.LoadInt64(&s.System.Retained))
+	require.Equal(t, int32(1), atomic.LoadInt32(&s.System.Retained))
 }
 
 func TestServerProcessPublishQoS2(t *testing.T) {
@@ -647,7 +647,7 @@ func TestServerProcessPublishQoS2(t *testing.T) {
 		0, 12, // Packet ID - LSB+MSB
 	}, <-ack1)
 
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.Retained))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.Retained))
 }
 
 func TestServerProcessPublishUnretain(t *testing.T) {
@@ -676,7 +676,7 @@ func TestServerProcessPublishUnretain(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	w1.Close()
 
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.Retained))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.Retained))
 }
 
 func TestServerProcessPublishOfflineQueuing(t *testing.T) {
@@ -715,7 +715,7 @@ func TestServerProcessPublishOfflineQueuing(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, int64(2), atomic.LoadInt64(&s.System.Inflight))
+	require.Equal(t, int32(2), atomic.LoadInt32(&s.System.Inflight))
 
 	time.Sleep(10 * time.Millisecond)
 	w1.Close()
@@ -805,7 +805,7 @@ func TestServerProcessPublishSystemPrefix(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, int64(0), s.System.BytesSent)
+	require.Equal(t, int32(0), s.System.BytesSent)
 }
 
 func TestServerProcessPublishBadACL(t *testing.T) {
@@ -843,7 +843,7 @@ func TestServerProcessPublishWriteAckError(t *testing.T) {
 func TestServerProcessPuback(t *testing.T) {
 	s, cl, _, _ := setupClient()
 	cl.Inflight.Set(11, clients.InflightMessage{Packet: packets.Packet{PacketID: 11}, Sent: 0})
-	atomic.AddInt64(&s.System.Inflight, 1)
+	atomic.AddInt32(&s.System.Inflight, 1)
 
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -853,7 +853,7 @@ func TestServerProcessPuback(t *testing.T) {
 		PacketID: 11,
 	})
 	require.NoError(t, err)
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.Inflight))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.Inflight))
 
 	_, ok := cl.Inflight.Get(11)
 	require.Equal(t, false, ok)
@@ -862,7 +862,7 @@ func TestServerProcessPuback(t *testing.T) {
 func TestServerProcessPubrec(t *testing.T) {
 	s, cl, r, w := setupClient()
 	cl.Inflight.Set(12, clients.InflightMessage{Packet: packets.Packet{PacketID: 12}, Sent: 0})
-	atomic.AddInt64(&s.System.Inflight, 1)
+	atomic.AddInt32(&s.System.Inflight, 1)
 
 	recv := make(chan []byte)
 	go func() {
@@ -883,7 +883,7 @@ func TestServerProcessPubrec(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(10 * time.Millisecond)
 	w.Close()
-	require.Equal(t, int64(1), atomic.LoadInt64(&s.System.Inflight))
+	require.Equal(t, int32(1), atomic.LoadInt32(&s.System.Inflight))
 
 	require.Equal(t, []byte{
 		byte(packets.Pubrel<<4) | 2, 2,
@@ -909,7 +909,7 @@ func TestServerProcessPubrecError(t *testing.T) {
 func TestServerProcessPubrel(t *testing.T) {
 	s, cl, r, w := setupClient()
 	cl.Inflight.Set(10, clients.InflightMessage{Packet: packets.Packet{PacketID: 10}, Sent: 0})
-	atomic.AddInt64(&s.System.Inflight, 1)
+	atomic.AddInt32(&s.System.Inflight, 1)
 
 	recv := make(chan []byte)
 	go func() {
@@ -928,7 +928,7 @@ func TestServerProcessPubrel(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.Inflight))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.Inflight))
 	time.Sleep(10 * time.Millisecond)
 	w.Close()
 
@@ -955,7 +955,7 @@ func TestServerProcessPubrelError(t *testing.T) {
 func TestServerProcessPubcomp(t *testing.T) {
 	s, cl, _, _ := setupClient()
 	cl.Inflight.Set(11, clients.InflightMessage{Packet: packets.Packet{PacketID: 11}, Sent: 0})
-	atomic.AddInt64(&s.System.Inflight, 1)
+	atomic.AddInt32(&s.System.Inflight, 1)
 
 	err := s.processPacket(cl, packets.Packet{
 		FixedHeader: packets.FixedHeader{
@@ -965,7 +965,7 @@ func TestServerProcessPubcomp(t *testing.T) {
 		PacketID: 11,
 	})
 	require.NoError(t, err)
-	require.Equal(t, int64(0), atomic.LoadInt64(&s.System.Inflight))
+	require.Equal(t, int32(0), atomic.LoadInt32(&s.System.Inflight))
 
 	_, ok := cl.Inflight.Get(11)
 	require.Equal(t, false, ok)
@@ -1628,7 +1628,7 @@ func TestServerResendClientInflightDropMessage(t *testing.T) {
 
 	m := cl.Inflight.GetAll()
 	require.Equal(t, 0, len(m))
-	require.Equal(t, int64(1), atomic.LoadInt64(&s.System.PublishDropped))
+	require.Equal(t, int32(1), atomic.LoadInt32(&s.System.PublishDropped))
 }
 
 func TestServerResendClientInflightError(t *testing.T) {

--- a/server/system/system.go
+++ b/server/system/system.go
@@ -6,19 +6,19 @@ type Info struct {
 	Version             string `json:"version"`              // the current version of the server.
 	Started             int64  `json:"started"`              // the time the server started in unix seconds.
 	Uptime              int64  `json:"uptime"`               // the number of seconds the server has been online.
-	BytesRecv           int64  `json:"bytes_recv"`           // the total number of bytes received in all packets.
-	BytesSent           int64  `json:"bytes_sent"`           // the total number of bytes sent to clients.
-	ClientsConnected    int64  `json:"clients_connected"`    // the number of currently connected clients.
-	ClientsDisconnected int64  `json:"clients_disconnected"` // the number of disconnected non-cleansession clients.
-	ClientsMax          int64  `json:"clients_max"`          // the maximum number of clients that have been concurrently connected.
-	ClientsTotal        int64  `json:"clients_total"`        // the sum of all clients, connected and disconnected.
-	ConnectionsTotal    int64  `json:"connections_total"`    // the sum number of clients which have ever connected.
-	MessagesRecv        int64  `json:"messages_recv"`        // the total number of packets received.
-	MessagesSent        int64  `json:"messages_sent"`        // the total number of packets sent.
-	PublishDropped      int64  `json:"publish_dropped"`      // the number of in-flight publish messages which were dropped.
-	PublishRecv         int64  `json:"publish_recv"`         // the total number of received publish packets.
-	PublishSent         int64  `json:"publish_sent"`         // the total number of sent publish packets.
-	Retained            int64  `json:"retained"`             // the number of messages currently retained.
-	Inflight            int64  `json:"inflight"`             // the number of messages currently in-flight.
-	Subscriptions       int64  `json:"subscriptions"`        // the total number of filter subscriptions.
+	BytesRecv           int32  `json:"bytes_recv"`           // the total number of bytes received in all packets.
+	BytesSent           int32  `json:"bytes_sent"`           // the total number of bytes sent to clients.
+	ClientsConnected    int32  `json:"clients_connected"`    // the number of currently connected clients.
+	ClientsDisconnected int32  `json:"clients_disconnected"` // the number of disconnected non-cleansession clients.
+	ClientsMax          int32  `json:"clients_max"`          // the maximum number of clients that have been concurrently connected.
+	ClientsTotal        int32  `json:"clients_total"`        // the sum of all clients, connected and disconnected.
+	ConnectionsTotal    int32  `json:"connections_total"`    // the sum number of clients which have ever connected.
+	MessagesRecv        int32  `json:"messages_recv"`        // the total number of packets received.
+	MessagesSent        int32  `json:"messages_sent"`        // the total number of packets sent.
+	PublishDropped      int32  `json:"publish_dropped"`      // the number of in-flight publish messages which were dropped.
+	PublishRecv         int32  `json:"publish_recv"`         // the total number of received publish packets.
+	PublishSent         int32  `json:"publish_sent"`         // the total number of sent publish packets.
+	Retained            int32  `json:"retained"`             // the number of messages currently retained.
+	Inflight            int32  `json:"inflight"`             // the number of messages currently in-flight.
+	Subscriptions       int32  `json:"subscriptions"`        // the total number of filter subscriptions.
 }


### PR DESCRIPTION
To support ARM32, we had to replace int64 types with int32.